### PR TITLE
Fix RT calc by resetting a variable

### DIFF
--- a/Main_EyeLink_narrative.m
+++ b/Main_EyeLink_narrative.m
@@ -452,6 +452,7 @@ try
     for i = 1:numTrials
         trialStart = GetSecs;
         response = -1; % reset on each trial
+        lastPressed = -1;
         
         % Before running trial, see if it's time for a break:
         takeABreak(i,numTrials);


### PR DESCRIPTION
In certain cases, you could get an RT even if NO BUTTON WAS PRESSED that trial, because the state of `lastPressed` from the previous trial rolled over. The RT logic assumed that lastPressed defaulted to -1, but it didn't. That's now fixed.